### PR TITLE
[bugfix] choice 타입 메시지일 때 빈 메시지가 표시되는 현상 수정

### DIFF
--- a/modules/channel-web/src/views/lite/components/messages/Message.tsx
+++ b/modules/channel-web/src/views/lite/components/messages/Message.tsx
@@ -126,7 +126,15 @@ class Message extends Component<MessageProps> {
       ...sanitizedProps,
       ...messageDataProps,
       keyboard: Keyboard,
-      children: wrapped && <Message {...sanitizedProps} keyboard={Keyboard} noBubble payload={wrapped} />
+      children: wrapped && (
+        <Message
+          {...sanitizedProps}
+          keyboard={Keyboard}
+          noBubble
+          hideEmptyMessage={wrapped.hideEmptyMessage}
+          payload={wrapped}
+        />
+      )
     }
 
     return <InjectedModuleView moduleName={module} componentName={component} lite extraProps={props} />
@@ -161,7 +169,7 @@ class Message extends Component<MessageProps> {
   }
 
   render_link() {
-    return <Link btn={this.props.payload.elements?.[0].buttons[0]}/>
+    return <Link btn={this.props.payload.elements?.[0].buttons[0]} />
   }
 
   async onMessageClicked() {
@@ -192,6 +200,20 @@ class Message extends Component<MessageProps> {
 
     const additionalStyle = (this.props.payload && this.props.payload['web-style']) || {}
 
+    // 메시지 타입이 text이고 text가 빈 텍스트일 때는 메시지 숨김 처리
+    if (this.props.hideEmptyMessage || this.props.payload?.wrapped?.hideEmptyMessage) {
+      return (
+        <>
+          {(type !== 'text' || (type === 'text' && this.props.payload?.text)) && (
+            <div className={classnames(this.props.className, wrappedClass)} style={additionalStyle}>
+              <div>{rendered}</div>
+              <div>{this.props.store.config.showTimestamp && this.props.isLastOfGroup && this.renderTimestamp()}</div>
+            </div>
+          )}
+        </>
+      )
+    }
+
     if (this.props.noBubble || this.props.payload?.wrapped?.noBubble) {
       return (
         <div className={classnames(this.props.className, wrappedClass)} style={additionalStyle}>
@@ -200,7 +222,7 @@ class Message extends Component<MessageProps> {
       )
     }
 
-    if (this.props.payload.elements?.[0].title==="용어사전") {
+    if (this.props.payload.elements?.[0].title === '용어사전') {
       return (
         <div className={classnames(this.props.className, wrappedClass)} style={additionalStyle}>
           {this.render_link()}

--- a/modules/channel-web/src/views/lite/components/messages/Message.tsx
+++ b/modules/channel-web/src/views/lite/components/messages/Message.tsx
@@ -204,7 +204,7 @@ class Message extends Component<MessageProps> {
     if (this.props.hideEmptyMessage || this.props.payload?.wrapped?.hideEmptyMessage) {
       return (
         <>
-          {(type !== 'text' || (type === 'text' && this.props.payload?.text)) && (
+          {(type !== 'text' || (type === 'text' && !!this.props.payload?.text)) && (
             <div className={classnames(this.props.className, wrappedClass)} style={additionalStyle}>
               <div>{rendered}</div>
               <div>{this.props.store.config.showTimestamp && this.props.isLastOfGroup && this.renderTimestamp()}</div>

--- a/modules/channel-web/src/views/lite/typings.d.ts
+++ b/modules/channel-web/src/views/lite/typings.d.ts
@@ -37,6 +37,8 @@ export namespace Renderer {
     noBubble?: boolean
     keyboard?: any
     eventId?: string
+    /** true이면 메시지 숨김 처리 */
+    hideEmptyMessage?: boolean
 
     isHighlighted?: boolean
     isLastGroup?: boolean

--- a/packages/ui-shared-lite/Payloads/index.ts
+++ b/packages/ui-shared-lite/Payloads/index.ts
@@ -86,6 +86,7 @@ const renderChoicePayload = (content: sdk.ChoiceContent & ExtraChoiceProperties)
     disableFreeText: content.disableFreeText,
     wrapped: {
       type: 'text',
+      hideEmptyMessage: !content.text,
       ...omit(content, 'choices', 'type')
     }
   }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29051383/190308180-860a40ce-c47f-4379-a401-cd4aa5905288.png)

질문들을 선택하는 버튼 UI 영역이 나타날 때, 봇에 빈 메시지가 표시되는 현상
choice 타입의 메시지일 때 질문들을 선택하는 버튼 UI 영역이 나타남
choice 타입의 메시지의 payload의 text가 없어서 빈 메시지가 표시됨   

choice 타입의 메시지 텍스트가 빈 텍스트일 경우 숨김 처리되도록 추가 구현